### PR TITLE
Fix frontmatter parsing error handling

### DIFF
--- a/obsidiantools/md_utils.py
+++ b/obsidiantools/md_utils.py
@@ -241,18 +241,15 @@ def _get_md_front_matter_and_content(filepath):
     """parse md file into front matter and note content"""
     with open(filepath) as f:
         try:
-            front_matter, content = frontmatter.parse(f.read())
+            file_string = f.read()
+            return frontmatter.parse(file_string)
         except yaml.scanner.ScannerError:
-            # for invalid YAML, return the whole file as content:
-            return {}, frontmatter.parse(f.read())
-    return (front_matter, content)
-
+            return {}, file_string
 
 def _get_html_from_md_file(filepath):
     """md file -> html (without front matter)"""
     _, content = _get_md_front_matter_and_content(filepath)
     return markdown.markdown(content, output_format='html')
-
 
 def _get_ascii_plaintext_from_html(html):
     """html -> ASCII plaintext, via HTML2Text."""


### PR DESCRIPTION
In your error handling case I think you meant to return the entire file content unparsed. As it currently is it reads the file again, gets an empty string, then frontmatter parses that string and gets back `({}, '')`. So `_get_md_front_matter_and_content` ends up returning `({}, ({}, ''))`