### PR TITLE
Fix get_md_relpaths_from_dir() error on MacOS

### DIFF
--- a/obsidiantools/md_utils.py
+++ b/obsidiantools/md_utils.py
@@ -26,7 +26,7 @@ def get_md_relpaths_from_dir(dir_path):
         list of Path objects
     """
     return [Path(p).relative_to(dir_path)
-            for p in glob(str(dir_path / '**/*.md'), recursive=True)]
+            for p in glob(f"{dir_path}/**/*.md", recursive=True)]
 
 
 def get_md_relpaths_matching_subdirs(dir_path, *,


### PR DESCRIPTION
Running the example from the readme on MacOS gives the below error:

```bash
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    vault = otools.Vault(VAULT_DIRECTORY).connect().gather()
  File "api.py", line 89, in __init__
    self._file_index = self._get_md_relpaths_by_name(
  File "/obsidiantools/obsidiantools/api.py", line 434, in _get_md_relpaths_by_name
    return {f.stem: f for f in self._get_md_relpaths(**kwargs)}
  File "/obsidiantools/obsidiantools/api.py", line 424, in _get_md_relpaths
    return get_md_relpaths_matching_subdirs(self._dirpath, **kwargs)
  File "/obsidiantools/obsidiantools/md_utils.py", line 62, in get_md_relpaths_matching_subdirs
    return get_md_relpaths_from_dir(dir_path)
  File "/obsidiantools/obsidiantools/md_utils.py", line 29, in get_md_relpaths_from_dir
    for p in glob(str(dir_path / '**/*.md'), recursive=True)]
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

The error is due to oddities in the glob module on MacOS, it can be fixed by  passing an f'string to the glob function call in `get_md_relpaths_from_dir(),  rather than performing a type conversion using the str() function`:

Original:

```python
return [Path(p).relative_to(dir_path)
        for p in glob(str(dir_path / '**/*.md'), recursive=True)]
```

Changed:

```python
return [Path(p).relative_to(dir_path)
        for p in glob(f"{dir_path}/**/*.md", recursive=True)]
```

