### PR TITLE
Add setuptools to requirements_test file to enable CI/CD checks for Python 3.12+ to work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.12', '3.11', '3.10', '3.9']
+        python-version: ['3.13', '3.12', '3.11', '3.10', '3.9']
     env:
       OS: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.11', '3.10', '3.9']
+        python-version: ['3.12', '3.11', '3.10', '3.9']
     env:
       OS: ${{ matrix.os }}
     steps:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+setuptools
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
Python versions of 3.12 and higher would have CI/CD runs fail if those were added to the file, even though earlier versions were fine.  Logs pointed to `setuptools` not being available as the problem.  I added it to the explicit requirements of the requirements_test file and that's fixed the runs.