### PR TITLE
fix: ignore URL fragments in markdown links when parsing tags (#52)

### DIFF
--- a/obsidiantools/md_utils.py
+++ b/obsidiantools/md_utils.py
@@ -244,6 +244,8 @@ def get_tags(filepath: Path, *, show_nested: bool = False) -> list[str]:
         str_transform_func=_transform_md_file_string_for_tag_parsing)
     # remove wikilinks so that '#' headers are not caught:
     src_txt = _remove_wikilinks_from_source_text(src_txt)
+    # remove md link URLs so that '#' fragments in them are not caught:
+    src_txt = _remove_md_link_urls_from_source_text(src_txt)
     tags = _get_tags_from_source_text(src_txt, show_nested=show_nested)
     return tags
 
@@ -445,6 +447,12 @@ def _get_unique_md_links_from_source_text(src_txt: str) -> list[str]:
 
 def _remove_wikilinks_from_source_text(src_txt: str) -> str:
     return re.sub(WIKILINK_REGEX, '', src_txt)
+
+
+def _remove_md_link_urls_from_source_text(src_txt: str) -> str:
+    # replace '[text](<url>)' with its 'text' so that any '#' fragment
+    # in the URL is not mistaken for a tag, while keeping the link text:
+    return re.sub(INLINE_LINK_AFTER_HTML_PROC_REGEX, r'\1', src_txt)
 
 
 def _transform_md_file_string_for_tag_parsing(txt: str) -> str:

--- a/tests/general/tags_url-fragment.md
+++ b/tests/general/tags_url-fragment.md
@@ -1,0 +1,7 @@
+# Tags vs URL fragments
+
+thanks to [Vite's HMR feature](https://vitejs.dev/guide/features.html#hot-module-replacement).
+
+A real tag: #python
+
+Another link [docs](https://example.com/page#section-two) followed by #data text.

--- a/tests/test_md_utils.py
+++ b/tests/test_md_utils.py
@@ -260,6 +260,22 @@ def test_sussudio_tags_with_nesting_shown():
     assert actual_tags == expected_tags
 
 
+def test_url_fragments_in_md_links_not_parsed_as_tags():
+    # the '#' fragment of a markdown link URL must not be read as a tag,
+    # while genuine tags in the note are still captured (issue #52):
+    actual_tags = get_tags(
+        Path('.') / 'tests/general/tags_url-fragment.md')
+    expected_tags = ['python', 'data']
+    assert actual_tags == expected_tags
+
+
+def test_url_fragments_in_md_links_not_parsed_as_tags_with_nesting():
+    actual_tags = get_tags(
+        Path('.') / 'tests/general/tags_url-fragment.md', show_nested=True)
+    expected_tags = ['python', 'data']
+    assert actual_tags == expected_tags
+
+
 def test_embedded_files_alias_scaling():
     actual_embedded_images = get_embedded_files(
         Path('.') / 'tests/general/embedded-images_in-table.md')


### PR DESCRIPTION
## Summary

- A URL fragment inside a standard markdown link (e.g. `[Vite's HMR](https://vitejs.dev/guide/features.html#hot-module-replacement)`) was incorrectly returned as a tag (`hot-`).
- `get_tags` strips wikilinks before tag parsing but never strips standard markdown inline links, so the `#fragment` in a link URL reached the tag regex and matched.

## Changes

- `obsidiantools/md_utils.py`: added `_remove_md_link_urls_from_source_text`, which replaces `[text](url)` with its display text using the existing `INLINE_LINK_AFTER_HTML_PROC_REGEX`, and calls it in `get_tags` right after wikilink removal. Link text is preserved so a genuine `#tag` written in visible text is still captured; only the URL and its `#fragment` are dropped.
- `tests/general/tags_url-fragment.md`: new fixture reproducing the issue.
- `tests/test_md_utils.py`: two regression tests via the public `get_tags` API (default and `show_nested=True`). Both fail without the fix and pass with it.

Fixes #52