### PR TITLE
fix: include filename in UnicodeDecodeError during vault gather (#32)

### DIFF
--- a/obsidiantools/md_utils.py
+++ b/obsidiantools/md_utils.py
@@ -254,6 +254,13 @@ def _get_md_front_matter_and_content(filepath: Path, *,
             if str_transform_func:
                 file_string = str_transform_func(file_string)
             return frontmatter.parse(file_string)
+        # non-UTF-8 bytes: re-raise with the offending file path so the
+        # file can be identified (the bare except below would otherwise
+        # swallow this and raise a confusing UnboundLocalError):
+        except UnicodeDecodeError as e:
+            raise UnicodeDecodeError(
+                e.encoding, e.object, e.start, e.end,
+                f"{e.reason} (in file: {filepath})") from e
         # for invalid YAML, return the whole file as content:
         except yaml.scanner.ScannerError as e:
             print(f"Front matter not populated for {filepath.name}: {repr(e)}")

--- a/tests/test_md_utils.py
+++ b/tests/test_md_utils.py
@@ -235,6 +235,18 @@ def test_front_matter_parse_double_curly():
     assert actual_txt == expected_txt
 
 
+def test_non_utf8_file_error_includes_filepath(tmp_path):
+    # a file with non-UTF-8 bytes should raise a UnicodeDecodeError whose
+    # message identifies the offending file (issue #32)
+    fpath = tmp_path / 'invalid-encoding.md'
+    fpath.write_bytes(b'# Heading\n\xff invalid start byte\n')
+
+    with pytest.raises(UnicodeDecodeError) as exc_info:
+        get_front_matter(fpath)
+
+    assert str(fpath) in str(exc_info.value)
+
+
 def test_hash_char_parsing_func():
     # '\#' in md file keeps # but stops text from being a tag
     in_str = r"\#hash #tag"


### PR DESCRIPTION
## Summary

- When a vault note contains non-UTF-8 bytes, reading it raised a bare error with no indication of *which* file was at fault — unworkable for a user with tens of thousands of notes (see issue).
- Worse, the `UnicodeDecodeError` from `f.read()` in `_get_md_front_matter_and_content` was being swallowed by the trailing bare `except:`, which then tried to `return {}, file_string` where `file_string` was never assigned — so the user actually saw a confusing `UnboundLocalError` instead of the real decode error.
- This fix catches `UnicodeDecodeError` explicitly and re-raises it with the offending filepath appended to the message, so the failing file is immediately identifiable.

## Changes

- `obsidiantools/md_utils.py`: in `_get_md_front_matter_and_content`, added an explicit `except UnicodeDecodeError` (before the catch-all) that re-raises a `UnicodeDecodeError` with `(in file: <filepath>)` appended to the reason. Placed ahead of the bare `except:` so the decode error is no longer swallowed.
- `tests/test_md_utils.py`: added `test_non_utf8_file_error_includes_filepath`, which writes a temp file with an invalid `0xff` byte, calls the public `get_front_matter`, and asserts the raised `UnicodeDecodeError` message contains the filepath. Verified this test fails on the unpatched code (it raised `UnboundLocalError`) and passes with the fix.

Fixes #32